### PR TITLE
Add system deps to Dockerfile and remove packages.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,12 @@ WORKDIR /app
 
 
 COPY packages.txt ./
-RUN apt update -y  &&  apt upgrade -y
-RUN xargs apt install -y < packages.txt
-
+RUN apt-get update && apt-get install -y \
+    tesseract-ocr \
+    libtesseract-dev \
+    libpoppler-dev \
+    poppler-utils \
+    libgl1
 COPY requirements-docker.txt ./requirements.txt
 RUN pip install --upgrade pip
 RUN pip install --no-deps --no-cache-dir -r requirements.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '1.0'
-
 services:
   app:
     build: .

--- a/packages.txt
+++ b/packages.txt
@@ -1,5 +1,0 @@
-tesseract-ocr
-libtesseract-dev
-libpoppler-dev
-poppler-utils
-libgl1


### PR DESCRIPTION
Running `docker compose up` on Windows gave the following error:

```
 => ERROR [app  5/10] RUN xargs apt install -y < packages.txt                                           0.9s 
------
 > [app  5/10] RUN xargs apt install -y < packages.txt:
0.389
0.389 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
0.389
0.391 Reading package lists...
0.772 Building dependency tree...
0.879 Reading state information...
0.885 E: Unable to locate package tesseract-ocr
0.885 E: Unable to locate package libtesseract-dev
0.885 E: Unable to locate package libpoppler-dev
0.885 E: Unable to locate package poppler-utils
0.885 E: Unable to locate package libgl1
------
failed to solve: process "/bin/sh -c xargs apt install -y < packages.txt" did not complete successfully: exit code: 123
```

Strangely, this error didn't exist when running Docker on Linux.

Changed the Dockerfile to include the system packages following [Docker best practices](https://docs.docker.com/build/building/best-practices/#run).